### PR TITLE
fix:complete.phpにページ遷移できるようにしました。

### DIFF
--- a/src/public/index.php
+++ b/src/public/index.php
@@ -4,7 +4,7 @@
   
   <p>以下のフォームからお問い合わせください。</p>
   
-  <form action="./com.php" method="post">
+  <form action="complete.php" method="post">
 
     <table>
       <tr>
@@ -25,6 +25,7 @@
       <tr>
         <td></td>
         <td><button type="submit" name="button">送信</button></td>
+        <input type="submit" value="送信" />
       </tr>
 
     </table>


### PR DESCRIPTION
## 作業対象

[作業をした教材のURL]
[https://www.notion.so/34586f67d9694adf9b8035a72db67b57](url)
[作成したページのURL(index.php)]
(http://localhost:8080/index.php)

## 作業詳細
index.phpにて[送信ボタン]をクリックしてもcomplete.phpにページ遷移しないというエラーが起きていたので、修正しました。


https://github.com/mikan19/contactform-error/assets/128659635/11957114-9032-4e6a-a8ae-67bc662ec88e

